### PR TITLE
remove pip package instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ from source
     cd personal-backend
     pip install .
 
+from pip
+
+    pip install git+https://github.com/MycroftAI/personal-backend.git
     
 configure backend by editing/creating ~/.mycroft/personal_backend/personal_backend.conf
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,6 @@ from source
     cd personal-backend
     pip install .
 
-from pip
-
-    pip install personal-mycroft-backend
     
 configure backend by editing/creating ~/.mycroft/personal_backend/personal_backend.conf
 


### PR DESCRIPTION
in the readme it says you can install by pip

this was the case in my original repo, but i believe it should now be removed since it is not sourced from this repo and is starting to get out of sync

related to #6 