### PR TITLE
make default STT config just work

### DIFF
--- a/personal_mycroft_backend/settings.py
+++ b/personal_mycroft_backend/settings.py
@@ -62,7 +62,7 @@ MAIL_USERNAME = conf.get("mail_user", "xxx@gmail.com")
 MAIL_PASSWORD = conf.get("mail_password", "xxx")
 MAIL_DEFAULT_SENDER = conf.get("mail_sender", MAIL_USERNAME)
 
-STT_CONFIG = conf.get("stt") or {"module": "google"}
+STT_CONFIG = conf.get("stt") or {"module": "google", "google": {}}
 
 LANG = conf.get("lang", "en-us")
 


### PR DESCRIPTION
if user did not set stt config, the default that is created is not valid

STT engines will fail to load because self.config == None

issue reported here - https://chat.mycroft.ai/community/pl/zs4y4nsz6tnsjmytsroc99aeaa

speechrecognition will use a demo key if credential is None, when i suggested this in mycroft-core it was discouraged, maybe i should make it add a field for credential in the config so it throws an error when stt is called?

