### PR TITLE
fix route

### DIFF
--- a/personal_mycroft_backend/backend/device.py
+++ b/personal_mycroft_backend/backend/device.py
@@ -180,7 +180,7 @@ def get_device_routes(app, mail_sender):
         return nice_json(result)
 
 
-    @app.route("/" + API_VERSION + "/device", methods=['GET'])
+    @app.route("/" + API_VERSION + "/device/", methods=['GET'])
     @noindex
     @donation
     @requires_auth


### PR DESCRIPTION
device route was missing a "/" and was returning 404 instead of 401, which does not allow pairing