### PR TITLE
fix/credentials_check

### DIFF
--- a/personal_mycroft_backend/frontend/utils.py
+++ b/personal_mycroft_backend/frontend/utils.py
@@ -99,7 +99,7 @@ def credentials_valid(username, password):
     with session_scope() as s:
         user = s.query(User).filter(User.name.in_([username])).first()
         if user:
-            return bcrypt.checkpw(password.encode('utf8'), user.password.encode('utf8'))
+            return bcrypt.checkpw(password.encode('utf8'), user.password)
         else:
             return False
 


### PR DESCRIPTION
credentials check in frontend expects bytes but was receiving a str object, this was missed when moving from py2 to py3