### PR TITLE
Check if cert files actually exist

### DIFF
--- a/personal_mycroft_backend/settings.py
+++ b/personal_mycroft_backend/settings.py
@@ -42,7 +42,7 @@ SQL_DEVICES_URI = conf.get("devices_db",
 SSL = conf.get("ssl", False)
 SSL_CERT = conf.get("ssl_cert")
 SSL_KEY = conf.get("ssl_key")
-if not SSL_CERT or not SSL_KEY:
+if not exists(SSL_CERT) or not exists(SSL_KEY):
     SSL_CERT, SSL_KEY = create_self_signed_cert(join(DATA_PATH, "certs"),
                                                 "MycroftPersonalServer")
 


### PR DESCRIPTION
Currently the code just checks if the variables have been set. If you followed the guide, this will be true. However, the cert files aren't actually at the location mentioned in the config file.

This one-line change checks if the files actually exist.

Optionally, the code could still be improved. If for some reason the user has specified a different cert files path than `./mycroft/personal_backend/certs/`, then this code is hard-wired to generate the files at that location anyway. It might be better to check which location the user has specified, and then try to generate the cert files at that location if they don't exist.