### PR TITLE
ensure config is a dict

### DIFF
--- a/personal_mycroft_backend/stt/__init__.py
+++ b/personal_mycroft_backend/stt/__init__.py
@@ -26,7 +26,7 @@ class STT(object):
     def __init__(self):
         self.lang = LANG
         self.module = STT_CONFIG.get("module")
-        self.config = STT_CONFIG.get(self.module)
+        self.config = STT_CONFIG.get(self.module) or {}
         self.credential = self.config.get("credential", {})
         self.recognizer = Recognizer()
 


### PR DESCRIPTION
closes #51 

self.config could be None which raised an error when reading the credential